### PR TITLE
Optimizing, adding word Count, cleaner Output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,64 @@
 
 A simple cli app build using rust, to grep a user input pattern in a user input file
 
+Functionalities 
+- gives out the word count
+- checks presence of a user input pattern
+
 ```sh
 <path/to/bin/>simplegrep foostring path_to_text_file
 ```
 
-## Improvments and Next goals
+## Current Output 
+```
+cargo run -- dog ~/Public/testArtifacts/testSimplegrep.txt
+   Compiling simplegrep v0.1.0 (/Users/wano/Public/code/buildWithRust/simplegrep)
+    Finished dev [unoptimized + debuginfo] target(s) in 0.31s
+     Running `target/debug/simplegrep dog /Users/wano/Public/testArtifacts/testSimplegrep.txt`
+pattern "dog" in "/Users/wano/Public/testArtifacts/testSimplegrep.txt" true
+######################################
+on:1
+and:2
+good:2
+back:3
+to:2
+The:11
+house:1
+its:1
+nice:2
+when:1
+then:1
+ran:1
+very:1
+fat:1
+he:1
+jumped:2
+smiling:1
+were:1
+the:8
+fox:11
+at:3
+jumping:1
+now:1
+landed:1
+over:1
+dog:8
+A:1
+struck:1
+returned:2
+angry:1
+was:5
+not:1
+a:1
+limped:1
+knew:2
+forest:1
+######################################
+```
+
+## Improvments
 - Use `BufReader` to improve read speeds for the input document
-- Use a cleaner output format to show the results
-- It will be interesting to understand statistics of the pattern
 - Can we do more than 1 pattern as an input
 - Can we do a directory of Files as an input (as well keeping a file as an input)
 - Add some better CLI documnets such as `--help` and `--version`
+- Get a structured and formatted output, based on kind of output needed

--- a/README.md
+++ b/README.md
@@ -28,59 +28,60 @@ Options:
 
 ## Current Output 
 ```
-cargo run -- dog ~/Public/testArtifacts/testSimplegrep.txt
-   Compiling simplegrep v0.1.0 (/Users/wano/Public/code/buildWithRust/simplegrep)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.31s
-     Running `target/debug/simplegrep dog /Users/wano/Public/testArtifacts/testSimplegrep.txt`
-pattern "dog" in "/Users/wano/Public/testArtifacts/testSimplegrep.txt" true
+simplegrep % cargo run -- --pattern fox --path ~/Public/testArtifacts/testSimplegrep.txt
+    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
+     Running `target/debug/simplegrep --pattern fox --path /Users/wano/Public/testArtifacts/testSimplegrep.txt`
+pattern "fox" in "/Users/wano/Public/testArtifacts/testSimplegrep.txt" true
 ######################################
-on:1
-and:2
-good:2
-back:3
-to:2
-The:11
-house:1
-its:1
-nice:2
-when:1
-then:1
-ran:1
-very:1
-fat:1
-he:1
 jumped:2
-smiling:1
-were:1
-the:8
-fox:11
-at:3
-jumping:1
-now:1
-landed:1
-over:1
-dog:8
-A:1
-struck:1
-returned:2
 angry:1
+were:1
+fox:11
+jumping:1
+very:1
+he:1
+struck:1
+to:2
+A:1
+on:1
+now:1
+then:1
 was:5
-not:1
-a:1
-limped:1
-knew:2
+and:2
 forest:1
+dog:8
+over:1
+a:1
+fat:1
+the:8
+knew:2
+house:1
+not:1
+returned:2
+at:3
+nice:2
+ran:1
+limped:1
+when:1
+smiling:1
+its:1
+good:2
+landed:1
+The:11
+back:3
 ######################################
+
 ```
 
 ## Improvments
-- Use `BufReader` to improve read speeds for the input document
+
 - Sort the output and print the top 10% 
 - add arg for each functionality
 - Can we do more than 1 pattern as an input
 - Can we do a directory of Files as an input (as well keeping a file as an input)
 - Add some better CLI documnets such as `--help` and `--version`
 - Get a structured and formatted output, based on kind of output needed
-- Take a input as a Large document and output a structured format 
+- Take a input as a Large document and output a structured format
+- Take a URI as an input and process that and output some logical data
 - Introduce Logging
 - Introduce tests 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ Functionalities
 
 ```sh
 <path/to/bin/>simplegrep foostring path_to_text_file
+
+simplegrep % cargo run -- --help
+   Compiling simplegrep v0.1.0 (/Users/wano/Public/code/buildWithRust/simplegrep)
+    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
+     Running `target/debug/simplegrep --help`
+
+Search and logically process patterns on the Command line
+
+Usage: simplegrep [OPTIONS]
+
+Options:
+  -r, --pattern <PATTERN>  The pattern to look for [default: ]
+  -p, --path <PATH>        The path of the file to read [default: ]
+  -h, --help               Print help
+  -V, --version            Print version
+
 ```
 
 ## Current Output 
@@ -59,7 +75,12 @@ forest:1
 
 ## Improvments
 - Use `BufReader` to improve read speeds for the input document
+- Sort the output and print the top 10% 
+- add arg for each functionality
 - Can we do more than 1 pattern as an input
 - Can we do a directory of Files as an input (as well keeping a file as an input)
 - Add some better CLI documnets such as `--help` and `--version`
 - Get a structured and formatted output, based on kind of output needed
+- Take a input as a Large document and output a structured format 
+- Introduce Logging
+- Introduce tests 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,27 +2,29 @@ use clap::Parser;
 use std::collections::HashMap;
 
 
-/// Search for a pattern in a file and display the lines that contain it
+/// Search and logically process patterns on the Command line
 #[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+
 struct Cli {
     /// The pattern to look for
+    #[arg(short='r', long, default_value="")]
     _pattern: String,
     
 
     /// The path of the file to read
+    #[arg(short, long, default_value="")]
     _path: std::path::PathBuf,
 }
 
 fn main() {
-    let _pattern = std::env::args().nth(1).expect("no pattern given");
-    let _path = std::env::args().nth(2).expect("no path given");
+    let _pattern = std::env::args().nth(1);
+    let _path = std::env::args().nth(2);
     
     let args = Cli::parse();
     let content = std::fs::read_to_string(&args._path).expect("could not read the file provided!");
     let mut check_pattern = false; 
-    let mut high_freq_wordmap: HashMap<String, i32> = HashMap::new();
-    // This can be dynamically done
-    //let high_freq_words = vec!["dog", "fox", "nice", "good"];
+    let mut high_freq_wordmap: HashMap<String, i32> = HashMap::new(); 
     for line in content.lines() {
         if line.contains(&args._pattern) {
             check_pattern = true;
@@ -31,7 +33,6 @@ fn main() {
             {
                 let mut temp_word = word.to_string(); 
                 temp_word.retain(|temp_word| !r#"()[]{},.*":'"#.contains(temp_word));
-                //println!("temp word {}", temp_word);
                 high_freq_wordmap.entry(temp_word).and_modify(|counter| *counter += 1).or_insert(1);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
-use std::io::BufReader;
-use std::fs::File;
+use std::collections::HashMap;
+
 
 /// Search for a pattern in a file and display the lines that contain it
 #[derive(Parser, Debug)]
@@ -13,18 +13,33 @@ struct Cli {
     _path: std::path::PathBuf,
 }
 
-
 fn main() {
     let _pattern = std::env::args().nth(1).expect("no pattern given");
     let _path = std::env::args().nth(2).expect("no path given");
     
     let args = Cli::parse();
     let content = std::fs::read_to_string(&args._path).expect("could not read the file provided!");
-    
+    let mut check_pattern = false; 
+    let mut high_freq_wordmap: HashMap<String, i32> = HashMap::new();
+    // This can be dynamically done
+    //let high_freq_words = vec!["dog", "fox", "nice", "good"];
     for line in content.lines() {
         if line.contains(&args._pattern) {
-            println!("{}", line);
+            check_pattern = true;
         }
+        for word in line.split_whitespace() {
+            {
+                let mut temp_word = word.to_string(); 
+                temp_word.retain(|temp_word| !r#"()[]{},.*":'"#.contains(temp_word));
+                //println!("temp word {}", temp_word);
+                high_freq_wordmap.entry(temp_word).and_modify(|counter| *counter += 1).or_insert(1);
+            }
+        }
+        }
+    println!("pattern {:?} in {:?} {:?}", args._pattern, args._path, check_pattern);
+    println!("######################################");
+    for (key, val) in high_freq_wordmap.iter() {
+        println!("{key}:{val}");
     }
-    println!("pattern {:?}, {:?}", args._pattern, args._path);
+    println!("######################################");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,14 @@
 use clap::Parser;
 use std::collections::HashMap;
+use std::io::{BufRead, BufReader};
+use std::fs::File;
 
 
 /// Search and logically process patterns on the Command line
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 
-struct Cli {
+struct Args {
     /// The pattern to look for
     #[arg(short='r', long, default_value="")]
     _pattern: String,
@@ -17,15 +19,19 @@ struct Cli {
     _path: std::path::PathBuf,
 }
 
-fn main() {
-    let _pattern = std::env::args().nth(1);
-    let _path = std::env::args().nth(2);
-    
-    let args = Cli::parse();
-    let content = std::fs::read_to_string(&args._path).expect("could not read the file provided!");
+fn main() -> Result<(), std::io::Error> { 
+    let args = Args::parse();
+    let f = File::open(&args._path).expect("Unable to open the file!");
+    let mut br = BufReader::new(f);
+    let mut line = String::new();
     let mut check_pattern = false; 
-    let mut high_freq_wordmap: HashMap<String, i32> = HashMap::new(); 
-    for line in content.lines() {
+    let mut high_freq_wordmap: HashMap<String, i32> = HashMap::new();
+
+    loop {
+        let content = br.read_line(&mut line)?;
+        if content == 0 {
+            break;
+        }
         if line.contains(&args._pattern) {
             check_pattern = true;
         }
@@ -36,11 +42,14 @@ fn main() {
                 high_freq_wordmap.entry(temp_word).and_modify(|counter| *counter += 1).or_insert(1);
             }
         }
-        }
+        line.clear();
+    }
     println!("pattern {:?} in {:?} {:?}", args._pattern, args._path, check_pattern);
     println!("######################################");
     for (key, val) in high_freq_wordmap.iter() {
         println!("{key}:{val}");
     }
     println!("######################################");
+
+    Ok(())
 }


### PR DESCRIPTION
- Using `BufReader` for optimizing reading from file
- `BufReader` is not a mandatory currently, as we are reading for one file, but that will change as we scale
- we are still using a string allocation since BufRead instance is a iterator and not a `String` 
- Cleaning out the output and `parse()` args, to make a more cleaner CLI app