### PR TITLE
[feature] error-stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+
+[[package]]
 name = "clap"
 version = "4.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +130,7 @@ dependencies = [
 name = "simplegrep"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.0", features = ["derive"]}
+anyhow = { version = "1.0"}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
 use std::fs::File;
+use anyhow::{Context, Result};
 
 
 /// Search and logically process patterns on the Command line
@@ -19,7 +20,7 @@ struct Args {
     _path: std::path::PathBuf,
 }
 
-fn main() -> Result<(), std::io::Error> { 
+fn main() -> Result<(), Box<dyn std::error::Error>> { 
     let args = Args::parse();
     let f = File::open(&args._path).expect("Unable to open the file!");
     let mut br = BufReader::new(f);
@@ -28,7 +29,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut high_freq_wordmap: HashMap<String, i32> = HashMap::new();
 
     loop {
-        let content = br.read_line(&mut line)?;
+        let content = br.read_line(&mut line).with_context(|| format!("could not read line"))?;
         if content == 0 {
             break;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ struct Args {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> { 
     let args = Args::parse();
-    let f = File::open(&args._path).expect("Unable to open the file!");
+    let f = File::open(&args._path).map_err(|_| "the correct file path is not provided")?;
     let mut br = BufReader::new(f);
     let mut line = String::new();
     let mut check_pattern = false; 


### PR DESCRIPTION
This PR introduces the crate `error-stack` for error reports

The purpose was to understand error reporting in rust, which is very detailed and is considered one of the best in business. 

There are various error libraries available such as [thiserror](https://crates.io/crates/thiserror) , [anyhow](https://github.com/dtolnay/anyhow), which are the more popular ones, but I wanted to personally delve into reports, as it seems a newer and deeper error handling mechanism. 

**Some of the places that inspired me to read about `error-stack`** escpecially hash.dev
- https://dev.to/randomengy/using-error-stack-with-tauri-3oa9?signin=true
- https://docs.rs/error-stack/latest/error_stack/
- https://hash.dev/blog/error-stack-update-0-2


**TODOs**
- Please create a separate file to import error mechanisms 